### PR TITLE
Add possibility to specify separate user for authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generic-smtp",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"main": "dist/index.js",
 	"scripts": {
 		"prepare": "husky",

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ export interface SMTPConfig {
 	secure: boolean
 	name: string
 	user: string
+	address: string
 }
 
 export interface OldSMTPConfig {
@@ -54,6 +55,12 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
 		{
 			type: 'textinput',
 			id: 'user',
+			label: 'user',
+			width: 6,
+		},
+		{
+			type: 'textinput',
+			id: 'address',
 			label: 'Address',
 			width: 6,
 		},

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ export interface SMTPConfig {
 	port: number
 	secure: boolean
 	name: string
+	specifyUser: boolean
 	user: string
 	address: string
 }
@@ -53,10 +54,19 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
 			width: 12,
 		},
 		{
+			type: 'checkbox',
+			id: 'specifyUser',
+			label: 'Specify separate user',
+			tooltip: 'if user needs to be different from address for authentication',
+			default: false,
+			width: 6,
+		},
+		{
 			type: 'textinput',
 			id: 'user',
-			label: 'user',
+			label: 'User',
 			width: 6,
+			isVisible: (config) => config.specifyUser === true,
 		},
 		{
 			type: 'textinput',

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export class SMTPInstance extends InstanceBase<SMTPConfig, SMTPSecrets> {
 			port: 465,
 			secure: true,
 			name: '',
+			specifyUser: false,
 			user: '',
 			address: '',
 		}
@@ -79,7 +80,7 @@ export class SMTPInstance extends InstanceBase<SMTPConfig, SMTPSecrets> {
 			port: Number(this.config.port),
 			secure: Boolean(this.config.secure),
 			auth: {
-				user: String(this.config.user),
+				user: this.config.specifyUser ? String(this.config.user) : String(this.config.address),
 				pass: String(this.secrets.password),
 			},
 		})

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export class SMTPInstance extends InstanceBase<SMTPConfig, SMTPSecrets> {
 			secure: true,
 			name: '',
 			user: '',
+			address: '',
 		}
 		this.secrets = { password: '' }
 		this.status = InstanceStatus.Connecting
@@ -84,7 +85,7 @@ export class SMTPInstance extends InstanceBase<SMTPConfig, SMTPSecrets> {
 		})
 
 		const mailDescription: SendMailOptions = {
-			from: `${this.config.name} <${this.config.user}>`,
+			from: `${this.config.name} <${this.config.address}>`,
 			to: mail.recipient,
 			subject: mail.subject,
 			html: mail.message,


### PR DESCRIPTION
For mail servers where there need to be a user separate from the e-mail address for authentication a checkbox is added to be able to enter the user name. If the checkbox remains unchecked the functionality is unchanged to the previous implementation.